### PR TITLE
fix: account for styles breaking when multiple speakers in a session

### DIFF
--- a/src/components/sessions/SessionCard.jsx
+++ b/src/components/sessions/SessionCard.jsx
@@ -65,7 +65,11 @@ function SessionCard({
       >
         <div className="flex items-center text-left">
           {speakerAvatars?.length && (
-            <div className="shrink-0 overflow-hidden rounded-full md:flex">
+            <div
+              className={`flex flex-wrap overflow-hidden ${
+                speakerAvatars?.length >= 3 ? 'gap-1' : 'rounded-full'
+              }`}
+            >
               {speakerAvatars.map((avatar, index) => (
                 <img
                   key={index}
@@ -77,7 +81,7 @@ function SessionCard({
                   alt={`Headshot of ${speakers[index]}`}
                   className={`${
                     speakerAvatars?.length >= 3
-                      ? 'size-20 lg:size-32'
+                      ? 'align-center mx-auto my-1 size-20 justify-center rounded-full lg:size-32'
                       : 'size-40'
                   } object-cover`}
                 />


### PR DESCRIPTION
# Pull Request

## Description

Multiple speakers on a session break the session card

Separate them if there are more than 3

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" -->

## Code Quality Checklist

<!-- Mark completed items with an "x" -->

- [X] Code follows the project's coding standards
- [X] Self-review of the code has been performed
- [X] Code is properly commented where necessary
- [X] No console.log statements left in the code
- [X] No hardcoded values that should be configurable
- [X] Error handling is implemented where appropriate

## Testing

<!-- Mark completed items with an "x" -->

- [X] Changes have been tested locally
- [X] All existing tests pass (if applicable)
- [X] New tests have been added for new functionality (if applicable)
- [X] Manual testing has been performed
- [X] Accessibility testing has been performed (for UI changes)

## Accessibility (for UI changes)

<!-- Mark completed items with an "x" -->

- [X] All interactive elements are keyboard accessible
- [X] Color contrast meets WCAG AA standards
- [X] Images have appropriate alt text
- [X] Form labels are properly associated
- [X] Focus indicators are visible
- [x] Screen reader compatibility has been tested

## Build & Deployment

<!-- Mark completed items with an "x" -->

- [X] Application builds successfully
- [X] No build warnings or errors
- [X] Dependencies are up to date
- [X] No security vulnerabilities introduced

## Screenshots (if applicable)

### Multiple Speakers issue

<img width="1030" height="570" alt="Screenshot 2025-11-07 at 3 51 24 PM" src="https://github.com/user-attachments/assets/c58e9aef-ead9-4354-9e58-0ff75a6ed6ff" />
<img width="931" height="602" alt="Screenshot 2025-11-07 at 3 51 30 PM" src="https://github.com/user-attachments/assets/17bd7bdc-d642-4bb2-8f87-665a41794d23" />

### Separate and wrap multiple speaker images

<img width="1571" height="344" alt="Screenshot 2025-11-07 at 3 57 11 PM" src="https://github.com/user-attachments/assets/ec205ce4-3063-4e5c-a5ee-1c93719a21ba" />
<img width="1613" height="370" alt="Screenshot 2025-11-07 at 3 57 21 PM" src="https://github.com/user-attachments/assets/dd6b85fb-dc61-460e-bb86-7d34b618cdc7" />
<img width="1076" height="499" alt="Screenshot 2025-11-07 at 3 57 34 PM" src="https://github.com/user-attachments/assets/e13511f8-5776-4ab8-b976-d253e92c2ff1" />
<img width="1263" height="354" alt="Screenshot 2025-11-07 at 3 57 29 PM" src="https://github.com/user-attachments/assets/06b2e690-0e54-43a9-8835-7236b30569a0" />
<img width="939" height="463" alt="Screenshot 2025-11-07 at 3 51 54 PM" src="https://github.com/user-attachments/assets/3b42edb5-e80c-41e1-a733-8d8731f8e462" />
<img width="1002" height="486" alt="Screenshot 2025-11-07 at 3 51 58 PM" src="https://github.com/user-attachments/assets/5bbb71f5-7e37-42c9-a876-fb8022f4eb2a" />
<img width="882" height="351" alt="Screenshot 2025-11-07 at 3 57 04 PM" src="https://github.com/user-attachments/assets/b57e54f1-9cb7-4fcb-9236-6fd61931218b" />



## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note**: This PR will be automatically checked for:

- Code quality (ESLint)
- Code formatting (Prettier)
- Build verification
- Accessibility compliance
- Security vulnerabilities

All checks must pass before this PR can be merged.
